### PR TITLE
Keep /run/wrappers/bin ahead of system PATH in interactive shells

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -126,9 +126,12 @@
   # Passwordless sudo for wheel group (setup user and future user)
   security.sudo.wheelNeedsPassword = false;
 
-  # Ensure system PATH is available in all interactive shells (including TTY autologin)
+  # Ensure system PATH is available in all interactive shells (including TTY
+  # autologin) WITHOUT shadowing the setuid wrappers. /run/wrappers/bin must
+  # stay ahead of /run/current-system/sw/bin or sudo/ping/mount/su lose their
+  # setuid bit ("must be owned by uid 0 and have the setuid bit set").
   environment.interactiveShellInit = ''
-    export PATH="/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:$PATH"
+    export PATH="/run/wrappers/bin:$PATH:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin"
   '';
 
   # Enable sound with pipewire


### PR DESCRIPTION
## Problem

`sudo` (and other setuid wrappers like `ping`, `mount`, `su`) failed in
interactive shells with:

> sudo: must be owned by uid 0 and have the setuid bit set

The `environment.interactiveShellInit` PATH override prepended
`/run/current-system/sw/bin` ahead of everything, which shadowed the setuid
wrappers in `/run/wrappers/bin`. The shell resolved `sudo` to the non-setuid
copy in the system profile instead of the wrapper.

## Fix

Reorder the PATH export so `/run/wrappers/bin` stays first, ensuring the
setuid wrappers always win, while still making the system profile paths
available for interactive/TTY-autologin shells:

```sh
export PATH="/run/wrappers/bin:$PATH:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin"
```

## Files Changed

- `modules/base.nix` — reorder interactive-shell PATH so wrapper bin dir leads